### PR TITLE
MU Plugin Webpack Entries compatibility

### DIFF
--- a/src/js/enqueues-theme-webpack-entries.js
+++ b/src/js/enqueues-theme-webpack-entries.js
@@ -1,54 +1,10 @@
 /**
+ * @deprecated Use 'enqueues-webpack-entries.js' instead.
+ * This file is retained for backwards compatibility and will be removed in a future major release.
+ * 
  * File Path: /src/js/enqueues-theme-webpack-entries.js
  */
 
-const enqueuesMergeThemeWebpackEntries = require('./enqueues-merge-webpack-entries');
+console.warn('[DEPRECATED] enqueues-theme-webpack-entries.js is deprecated. Please use enqueues-webpack-entries.js instead.');
 
-/**
- * @function enqueuesThemeWebpackEntries
- * @param {string} rootDir - The root directory path.
- * @param {object} pathModule - The `path` module to use for resolving paths.
- * @param {object} globModule - The `glob` module to use for matching file patterns.
- * @param {string} [srcDirJS='src/js'] - Directory path for JavaScript files.
- * @param {string} [srcDirCSS='src/sass'] - Directory path for SCSS files.
- * @param {string} [cssFileExt='scss'] - File extension for CSS files.
- * @description A function to dynamically resolve and group entry points for Webpack configuration.
- */
-const enqueuesThemeWebpackEntries = (rootDir, pathModule, globModule, srcDirJS = 'src/js', srcDirCSS = 'src/sass', cssFileExt = 'scss') => {
-    // Log for debugging
-    console.log('rootDir:', rootDir);
-    console.log('srcDirJS:', srcDirJS);
-    console.log('srcDirCSS:', srcDirCSS);
-
-    const safeGlobSync = (pattern) => {
-        try {
-            return globModule.sync(pattern);
-        } catch (error) {
-            console.error(`Failed to resolve pattern: ${pattern}`, error);
-            return [];
-        }
-    };
-
-    // Use dynamic directories for JS and SCSS files
-    const entriesJS = safeGlobSync(pathModule.resolve(rootDir, srcDirJS, '*.js'))
-        .reduce((obj, el) => {
-            const name = pathModule.parse(el).name;
-            obj[name] = [el];
-            return obj;
-        }, {});
-
-    const entriesCSS = safeGlobSync(pathModule.resolve(rootDir, srcDirCSS, `*.${cssFileExt}`))
-        .reduce((obj, el) => {
-            const name = pathModule.parse(el).name;
-            obj[name] = [el];
-            return obj;
-        }, {});
-
-    const entries = enqueuesMergeThemeWebpackEntries(entriesJS, entriesCSS);
-
-    console.log('Generated Entries from Enqueues Theme Webpack Entries:', entries);
-
-    return entries;
-};
-
-module.exports = enqueuesThemeWebpackEntries;
+module.exports = require('./enqueues-webpack-entries');

--- a/src/js/enqueues-webpack-entries.js
+++ b/src/js/enqueues-webpack-entries.js
@@ -1,0 +1,55 @@
+/**
+ * File Path: /src/js/enqueues-webpack-entries.js
+ */
+
+const enqueuesMergeThemeWebpackEntries = require('./enqueues-merge-webpack-entries');
+
+/**
+ * @function enqueuesWebpackEntries
+ * @param {string} rootDir - The root directory path.
+ * @param {object} pathModule - The `path` module to use for resolving paths.
+ * @param {object} globModule - The `glob` module to use for matching file patterns.
+ * @param {string} [srcDirJS='src/js'] - Directory path for JavaScript files.
+ * @param {string} [srcDirCSS='src/sass'] - Directory path for SCSS files.
+ * @param {string} [cssFileExt='scss'] - File extension for CSS files.
+ * @description A function to dynamically resolve and group entry points for Webpack configuration.
+ */
+const enqueuesWebpackEntries = (rootDir, pathModule, globModule, srcDirJS = 'src/js', srcDirCSS = 'src/sass', cssFileExt = 'scss') => {
+    console.log('rootDir:', rootDir);
+    console.log('srcDirJS:', srcDirJS);
+    console.log('srcDirCSS:', srcDirCSS);
+
+    const safeGlobSync = (pattern) => {
+        try {
+            return globModule.sync(pattern);
+        } catch (error) {
+            console.error(`Failed to resolve pattern: ${pattern}`, error);
+            return [];
+        }
+    };
+
+    // Use dynamic directories for JS and SCSS files, including one level down
+    const entriesJS = safeGlobSync(pathModule.resolve(rootDir, srcDirJS, '*.js'))
+        .concat(safeGlobSync(pathModule.resolve(rootDir, '*', srcDirJS, '*.js')))
+        .reduce((obj, el) => {
+            const name = pathModule.parse(el).name;
+            obj[name] = [el];
+            return obj;
+        }, {});
+
+    const entriesCSS = safeGlobSync(pathModule.resolve(rootDir, srcDirCSS, `*.${cssFileExt}`))
+        .concat(safeGlobSync(pathModule.resolve(rootDir, '*', srcDirCSS, `*.${cssFileExt}`)))
+        .reduce((obj, el) => {
+            const name = pathModule.parse(el).name;
+            obj[name] = [el];
+            return obj;
+        }, {});
+
+    const entries = enqueuesMergeThemeWebpackEntries(entriesJS, entriesCSS);
+
+    console.log('Generated Entries from Enqueues Webpack Entries:', entries);
+
+    return entries;
+};
+
+module.exports = enqueuesWebpackEntries;


### PR DESCRIPTION
This PR introduces a new, enhanced function enqueuesWebpackEntries which improves the handling of Webpack entry discovery for projects that follow varying folder structures, including deeply nested MU plugins. The existing enqueuesThemeWebpackEntries function remains temporarily available for backwards compatibility, but is now deprecated.

### Changes Introduced
Added enqueuesWebpackEntries, a modernised function for resolving Webpack entry points.
- Supports both standard theme structures (themes/<theme>/src/js) and
- MU plugin structures, including those with nested plugins one level deep, e.g.: wp-content/mu-plugins/<main-plugin>/<nested-plugin>/src/js

Deprecated the old enqueuesThemeWebpackEntries function and file:
- Added a console warning to notify users.
- Retained functionality by forwarding calls to the new enqueuesWebpackEntries file.
- Updated console logging to clarify root and entry path resolutions.
- Cleanly separated old and new logic to avoid breaking existing consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Deprecated an old module and redirected users to a new one for managing Webpack entry points. A deprecation warning is now shown, and the legacy module will be removed in a future major release.

- **New Features**
  - Introduced an improved module for dynamically resolving JavaScript and CSS/SCSS entry points for Webpack configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->