### PR TITLE
Add generic block child directory copy context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ENHANCEMENT**: Extended early block style pre-enqueue coverage for CLS prevention
   - Renamed pre-enqueue logic to handle both static and dynamic blocks found in page content
   - Early enqueue now covers frontend block style and view style handles for all matched blocks
+- **ENHANCEMENT**: Added generic block child directory copy context for Webpack copy patterns
+  - Added `block-child-dirs` context to `enqueuesGetCopyPluginConfigPattern`
+  - Supports custom source block directory, destination block directory, and multiple child directory names
 - **ENHANCEMENT**: Added explicit control for head pre-enqueue behaviour
   - Added `enqueues_block_editor_preenqueue_block_styles` filter to control forced head pre-enqueue
   - Pre-enqueue defaults to enabled for static and dynamic blocks, and can be disabled per site to fall back to WordPress behaviour
@@ -23,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BLOCK-EDITOR.md` with:
   - Core block style-loading defaults used by Enqueues
   - New `enqueues_block_editor_preenqueue_block_styles` filter details
+- Updated `WEBPACK.md` with `block-child-dirs` copy pattern usage and examples
 - Updated `FILTERS.md` to include `enqueues_block_editor_preenqueue_block_styles`
 - Updated `THEME-ASSETS.md` and `FILTERS.md` to document remap behaviour for post-name matching and candidate ordering
 

--- a/docs/WEBPACK.md
+++ b/docs/WEBPACK.md
@@ -9,7 +9,7 @@ It also helps with copying images, fonts, and other assets, and integrates with 
 - Use `enqueues-merge-webpack-entries.js` to merge dynamic and custom entries.
 - Use `enqueues-theme-webpack-entries.js` (deprecated) or `enqueues-webpack-entries.js` for theme asset entry generation.
 - Use `enqueues-block-editor-webpack-entries.js` for block editor asset entry generation.
-- Use `enqueues-copy-plugin-config-pattern.js` to generate CopyWebpackPlugin patterns for images, fonts, block JSON, and PHP render files.
+- Use `enqueues-copy-plugin-config-pattern.js` to generate CopyWebpackPlugin patterns for images, fonts, block JSON, PHP render files, and block child directories.
 
 ## EXAMPLE WEBPACK CONFIG
 ```js
@@ -187,9 +187,9 @@ const entries = enqueuesMergeWebpackEntries(
 
 This works for both main theme files and block editor files. See [THEME-ASSETS.md](THEME-ASSETS.md) for more on theme asset structure.
 
-## COPYING BLOCK JSON AND PHP RENDER FILES
+## COPYING BLOCK JSON, PHP RENDER FILES, AND BLOCK CHILD DIRECTORIES
 
-Use `enqueuesGetCopyPluginConfigPattern` with CopyWebpackPlugin to copy block JSON and PHP render files:
+Use `enqueuesGetCopyPluginConfigPattern` with CopyWebpackPlugin to copy block JSON, PHP render files, and specific child directories inside each block:
 
 ```js
 const copyPlugin = new CopyWebpackPlugin({
@@ -198,11 +198,22 @@ const copyPlugin = new CopyWebpackPlugin({
     enqueuesGetCopyPluginConfigPattern(rootDir, distDir, 'fonts'),
     enqueuesGetCopyPluginConfigPattern(rootDir, distDir, 'block-json'),
     enqueuesGetCopyPluginConfigPattern(rootDir, distDir, 'render-php'),
+    enqueuesGetCopyPluginConfigPattern(
+      rootDir,
+      distDir,
+      'block-child-dirs',
+      '**/src',
+      'block-editor/blocks',
+      ['assets', 'deprecated'],
+      'block-editor/blocks'
+    ),
   ],
 });
 ```
 
 This ensures block registration and server-side rendering work as expected.
+
+Use `block-child-dirs` when you need to copy one or more named directories from each block recursively.
 
 ## CLEANING UP BUILD OUTPUT
 
@@ -344,13 +355,22 @@ const jquery = new webpack.ProvidePlugin({
   'window.jQuery': 'jquery',
 });
 
-// Copy block JSON, PHP render files, images, and fonts
+// Copy block JSON, PHP render files, block child directories, images, and fonts
 const copyPlugin = new CopyWebpackPlugin({
   patterns: [
     enqueuesGetCopyPluginConfigPattern(rootDir, distDir, 'images'),
     enqueuesGetCopyPluginConfigPattern(rootDir, distDir, 'fonts'),
     enqueuesGetCopyPluginConfigPattern(rootDir, distDir, 'block-json'),
     enqueuesGetCopyPluginConfigPattern(rootDir, distDir, 'render-php'),
+    enqueuesGetCopyPluginConfigPattern(
+      rootDir,
+      distDir,
+      'block-child-dirs',
+      '**/src',
+      'block-editor/blocks',
+      ['assets', 'deprecated'],
+      'block-editor/blocks'
+    ),
   ],
 });
 


### PR DESCRIPTION
- add `block-child-dirs` context to `enqueuesGetCopyPluginConfigPattern`
- support custom `srcBlockDir`, `distBlockDir`, and string/array `childDirs`
- preserve existing `images`, `fonts`, `block-json`, and `render-php` usage defaults
- document `block-child-dirs` usage in `docs/WEBPACK.md`
- update changelog with new copy-pattern capability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for copying block child directories (such as assets) in Webpack copy patterns, enabling customisation of source and destination block directories with support for multiple child directory names.

* **Documentation**
  * Updated changelog and Webpack documentation to include new block child directories context, configuration options, practical examples, and implementation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->